### PR TITLE
refactor: Align PhoneNumberSyncService with custom objects

### DIFF
--- a/force-app/main/default/classes/PhoneNumberSyncService.cls
+++ b/force-app/main/default/classes/PhoneNumberSyncService.cls
@@ -14,64 +14,140 @@ public virtual class PhoneNumberSyncService { // Made class virtual for extensib
         this.numberServiceInstance = mockNumberService;
     }
 
+    // Inner class to hold remote assignment data along with its parent Series Id
+    public class RemoteAssignmentWrapper {
+        @TestVisible public NumberResDAO.NumberData numberData;
+        @TestVisible public Id parentSeriesId;
+
+        public RemoteAssignmentWrapper(NumberResDAO.NumberData data, Id seriesId) {
+            this.numberData = data;
+            this.parentSeriesId = seriesId;
+        }
+    }
+
     // Wrapper method for the static call to make it mockable in tests
     @TestVisible // Or protected if tests are in the same namespace and can extend
     protected virtual NumberResDAO.NumberDetails callGetNumberDetails(NumberService.GetNumbersParameterbuilder params) {
         return NumberService.getNumberDetails(params);
     }
 
+    // Method to get Account Phone Number Series records. Made virtual for potential test mocking.
+    @TestVisible
+    protected virtual List<Account_Phone_Number_Series__c> getAllAccountPhoneNumberSeries() {
+        return [
+            SELECT Id, Name, Number_Group__c, Number_Location__c, CVR__c, Number_Pattern_c, Product_type__c
+            FROM Account_Phone_Number_Series__c
+        ];
+    }
+
+    // Method to get OpenPhoneNumberSeries metadata. Made virtual for potential test mocking.
+    @TestVisible
+    protected virtual List<OpenPhoneNumberSeries__mdt> getOpenPhoneNumberSeriesMetadata() {
+        // Assuming API names NumberGroup__c and NumberLocation__c based on typical naming.
+        // User feedback: "OpenPhoneNumberSeries containing NumberGroup, NumberLocation"
+        // Adjust if API names are different (e.g., MasterLabel or DeveloperName if those store the group/location)
+        return [SELECT NumberGroup__c, NumberLocation__c FROM OpenPhoneNumberSeries__mdt];
+    }
+
     public void synchronizeAssignments() {
         Map<String, Account_Phone_Number_Assignment__c> localAssignments = getLocalAssignments();
-        Map<String, NumberResDAO.NumberData> remoteAssignments = getRemoteAssignments();
-        compareAndPrepareDML(localAssignments, remoteAssignments);
+        Map<String, RemoteAssignmentWrapper> remoteAssignments = getRemoteAssignments(); // Changed return type
+        compareAndPrepareDML(localAssignments, remoteAssignments); // Argument type changed
     }
 
     private Map<String, Account_Phone_Number_Assignment__c> getLocalAssignments() {
         Map<String, Account_Phone_Number_Assignment__c> localAssignmentsMap = new Map<String, Account_Phone_Number_Assignment__c>();
-        // TODO: Query all fields required for comparison and updates.
-        // For now, using Name and a placeholder 'Status__c' and 'Series__c'.
-        // Add other fields from Account_Phone_Number_Assignment__c as needed.
+
+        // Querying Account_Phone_Number_Assignment__c with its new fields
+        // Using Phone_Number__c as the key.
+        // Including fields from the parent Account_Phone_Number_Series__r for context.
         for (Account_Phone_Number_Assignment__c assignment : [
-            SELECT Id, Name, Status__c, Series__c
+            SELECT Id, Name, Phone_Number__c, CTN_Number_Status__c,
+                   Account_Phone_Number_Series__c, // Master-Detail Relationship ID
+                   Account_Phone_Number_Series__r.Name, // Name of the parent series
+                   Account_Phone_Number_Series__r.Number_Group__c,
+                   Account_Phone_Number_Series__r.Number_Location__c,
+                   Phone_Number_Reservation_Error__c,
+                   Phone_Number_Reservation_Status__c,
+                   Phone_Number_user__c,
+                   Account__c // Lookup to Account
             FROM Account_Phone_Number_Assignment__c
         ]) {
-            localAssignmentsMap.put(assignment.Name, assignment);
+            if (String.isNotBlank(assignment.Phone_Number__c)) {
+                localAssignmentsMap.put(assignment.Phone_Number__c.toLowerCase(), assignment); // Key by lowercase phone number for case-insensitivity
+            }
         }
         return localAssignmentsMap;
     }
 
-    private Map<String, NumberResDAO.NumberData> getRemoteAssignments() {
-        Map<String, NumberResDAO.NumberData> remoteAssignmentsMap = new Map<String, NumberResDAO.NumberData>();
-        Set<String> openSeries = new Set<String>();
-        for (OpenPhoneNumberSeries__mdt series : [SELECT MasterLabel, DeveloperName FROM OpenPhoneNumberSeries__mdt]) {
-            // Assuming DeveloperName holds the series identifier that matches NumberService's numberGroup
-            openSeries.add(series.DeveloperName);
+    private Map<String, RemoteAssignmentWrapper> getRemoteAssignments() {
+        Map<String, RemoteAssignmentWrapper> remoteAssignmentsMap = new Map<String, RemoteAssignmentWrapper>();
+
+        // 1. Get all Account Phone Number Series
+        List<Account_Phone_Number_Series__c> allSeriesRecords = getAllAccountPhoneNumberSeries();
+        if (allSeriesRecords.isEmpty()) {
+            System.debug('No Account_Phone_Number_Series__c records found. No remote assignments to fetch.');
+            return remoteAssignmentsMap;
         }
 
-        // TODO: Replace this with actual logic to get all number series
-        List<String> allSeries = new List<String>{'Series1', 'Series2', 'OpenSeries1'};
+        // 2. Get OpenPhoneNumberSeries metadata
+        Set<String> openSeriesKeys = new Set<String>();
+        for (OpenPhoneNumberSeries__mdt opsMeta : getOpenPhoneNumberSeriesMetadata()) {
+            // Create a unique key for comparison, e.g., "P_EKC"
+            if (String.isNotBlank(opsMeta.NumberGroup__c) && String.isNotBlank(opsMeta.NumberLocation__c)) {
+                openSeriesKeys.add(opsMeta.NumberGroup__c.toUpperCase() + '_' + opsMeta.NumberLocation__c.toUpperCase());
+            }
+        }
+        System.debug('Open Series Keys from CMD: ' + openSeriesKeys);
 
         List<String> defaultStatuses = new List<String>{'AA', 'AR', 'AI', 'AS'};
         List<String> openSeriesStatuses = new List<String>{'AR'};
 
-        for (String currentSeries : allSeries) {
-            List<String> statusesToQuery = openSeries.contains(currentSeries) ? openSeriesStatuses : defaultStatuses;
+        // 3. Iterate through each Account_Phone_Number_Series__c record
+        for (Account_Phone_Number_Series__c seriesRecord : allSeriesRecords) {
+            String currentSeriesKey = '';
+            if (String.isNotBlank(seriesRecord.Number_Group__c) && String.isNotBlank(seriesRecord.Number_Location__c)) {
+                currentSeriesKey = seriesRecord.Number_Group__c.toUpperCase() + '_' + seriesRecord.Number_Location__c.toUpperCase();
+            }
+
+            boolean isSeriesOpen = openSeriesKeys.contains(currentSeriesKey);
+            List<String> statusesToQuery = isSeriesOpen ? openSeriesStatuses : defaultStatuses;
+
+            System.debug('Processing Series: ' + seriesRecord.Name +
+                         ', Group: ' + seriesRecord.Number_Group__c +
+                         ', Location: ' + seriesRecord.Number_Location__c +
+                         ', IsOpen: ' + isSeriesOpen +
+                         ', Statuses: ' + statusesToQuery);
+
             for (String status : statusesToQuery) {
                 NumberService.GetNumbersParameterbuilder params = new NumberService.GetNumbersParameterbuilder();
-                params.withNumberGroup(currentSeries);
+                params.withNumberGroup(seriesRecord.Number_Group__c);
+                params.withNumberLocation(seriesRecord.Number_Location__c);
+                params.withCvr(seriesRecord.CVR__c);
+                params.withNumberPattern(seriesRecord.Number_Pattern_c);
+                // Note: Product_type__c from seriesRecord.Product_type__c is not directly used by
+                // the current NumberService.GetNumbersParameterbuilder().build() which hardcodes GSM.
+                // This might be an area for future enhancement if the builder needs to be more dynamic.
                 params.withNumberStatus(status);
+                // params.withAmountOfNumbers(X); // Consider pagination
 
-                // Use the wrapper method instead of direct static call
                 NumberResDAO.NumberDetails details = callGetNumberDetails(params);
 
                 if (details != null && details.data != null) {
                     for (NumberResDAO.NumberData numberData : details.data) {
                         if (String.isNotBlank(numberData.phoneNumber)) {
-                            remoteAssignmentsMap.put(numberData.phoneNumber, numberData);
+                            // Key by lowercase phone number for case-insensitivity
+                            remoteAssignmentsMap.put(
+                                numberData.phoneNumber.toLowerCase(),
+                                new RemoteAssignmentWrapper(numberData, seriesRecord.Id)
+                            );
                         }
                     }
                 } else if (details != null && details.error != null) {
-                    System.debug('Error fetching remote numbers for series ' + currentSeries + ' with status ' + status + ': ' + details.error.message);
+                    System.debug('Error fetching remote numbers for Series Name ' + seriesRecord.Name +
+                                 ' (Group: ' + seriesRecord.Number_Group__c +
+                                 ', Location: ' + seriesRecord.Number_Location__c +
+                                 ') with status ' + status + ': ' + details.error.message);
                 }
             }
         }
@@ -80,43 +156,72 @@ public virtual class PhoneNumberSyncService { // Made class virtual for extensib
 
     private void compareAndPrepareDML(
         Map<String, Account_Phone_Number_Assignment__c> localAssignments,
-        Map<String, NumberResDAO.NumberData> remoteAssignments
+        Map<String, RemoteAssignmentWrapper> remoteAssignments
     ) {
         List<Account_Phone_Number_Assignment__c> toCreate = new List<Account_Phone_Number_Assignment__c>();
         List<Account_Phone_Number_Assignment__c> toUpdate = new List<Account_Phone_Number_Assignment__c>();
         List<Account_Phone_Number_Assignment__c> toDelete = new List<Account_Phone_Number_Assignment__c>();
 
         // Iterate through remote assignments to find new or changed records
-        for (String remoteKey : remoteAssignments.keySet()) {
-            NumberResDAO.NumberData remoteData = remoteAssignments.get(remoteKey);
+        for (String remoteKey : remoteAssignments.keySet()) { // remoteKey is already lowercased
+            RemoteAssignmentWrapper wrapper = remoteAssignments.get(remoteKey);
+            NumberResDAO.NumberData remoteData = wrapper.numberData;
+            Id parentSeriesIdForRemote = wrapper.parentSeriesId;
+
             Account_Phone_Number_Assignment__c localRecord = localAssignments.get(remoteKey);
 
             if (localRecord == null) {
+                // New record: create it
                 Account_Phone_Number_Assignment__c newAssignment = new Account_Phone_Number_Assignment__c();
-                newAssignment.Name = remoteData.phoneNumber;
-                newAssignment.Status__c = remoteData.numberStatus;
-                newAssignment.Series__c = remoteData.numberGroup;
+
+                newAssignment.Phone_Number__c = remoteData.phoneNumber; // Store with original casing
+                newAssignment.CTN_Number_Status__c = remoteData.numberStatus;
+                newAssignment.Account_Phone_Number_Series__c = parentSeriesIdForRemote; // Set Master-Detail relationship
+
+                // TODO: Map other fields from remoteData to newAssignment if necessary
+                // e.g., newAssignment.Phone_Number_user__c = remoteData.someUserField;
+                // e.g., newAssignment.Account__c = determineAccountIdLogic();
+                // For now, only core fields are mapped.
+
                 toCreate.add(newAssignment);
+                System.debug('To Create: Phone=' + remoteData.phoneNumber + ', Status=' + remoteData.numberStatus + ', SeriesId=' + parentSeriesIdForRemote);
+
             } else {
+                // Existing record: check for changes
                 boolean changed = false;
-                if (localRecord.Status__c != remoteData.numberStatus) {
-                    localRecord.Status__c = remoteData.numberStatus;
+
+                // Compare CTN_Number_Status__c
+                if (localRecord.CTN_Number_Status__c != remoteData.numberStatus) {
+                    localRecord.CTN_Number_Status__c = remoteData.numberStatus;
                     changed = true;
                 }
-                if (localRecord.Series__c != remoteData.numberGroup) {
-                    localRecord.Series__c = remoteData.numberGroup;
-                    changed = true;
-                }
+
+                // TODO: Compare other relevant fields from remoteData and update localRecord if changed.
+                // Example:
+                // if (localRecord.Phone_Number_user__c != remoteData.someUserField) {
+                //    localRecord.Phone_Number_user__c = remoteData.someUserField;
+                //    changed = true;
+                // }
+
+                // Note: The parentSeriesId (Account_Phone_Number_Series__c) for an existing localRecord
+                // is generally not expected to change based on remote data for the *same phone number*.
+                // If a phone number were to move series, it might appear as a delete from old series
+                // and an add to new series, depending on how NumberService reports it.
+                // We are not updating localRecord.Account_Phone_Number_Series__c here.
+
                 if (changed) {
                     toUpdate.add(localRecord);
+                    System.debug('To Update: Phone=' + localRecord.Phone_Number__c + ', NewStatus=' + localRecord.CTN_Number_Status__c);
                 }
             }
         }
 
-        for (String localKey : localAssignments.keySet()) {
-        for (String localKey : localAssignments.keySet()) {
+        // Iterate through local assignments to find records for deletion
+        for (String localKey : localAssignments.keySet()) { // localKey is lowercased Phone_Number__c
             if (!remoteAssignments.containsKey(localKey)) {
-                toDelete.add(localAssignments.get(localKey));
+                Account_Phone_Number_Assignment__c assignmentToDelete = localAssignments.get(localKey);
+                toDelete.add(assignmentToDelete);
+                System.debug('To Delete: Phone=' + assignmentToDelete.Phone_Number__c + ', Id=' + assignmentToDelete.Id);
             }
         }
 

--- a/force-app/main/default/classes/PhoneNumberSyncServiceTests.cls
+++ b/force-app/main/default/classes/PhoneNumberSyncServiceTests.cls
@@ -1,233 +1,326 @@
 @isTest
 private class PhoneNumberSyncServiceTests {
 
-    // Helper to create Account_Phone_Number_Assignment__c records for testing
-    private static Account_Phone_Number_Assignment__c createLocalAssignment(String phoneNumber, String status, String series) {
+    // Helper to create Account_Phone_Number_Series__c for testing
+    private static Account_Phone_Number_Series__c createTestSeries(
+        String numberGroup, String numberLocation, String cvr, String pattern, String productType
+    ) {
+        // Name is an Auto Number field, so we don't set it.
+        Account_Phone_Number_Series__c series = new Account_Phone_Number_Series__c(
+            Number_Group__c = numberGroup,
+            Number_Location__c = numberLocation,
+            CVR__c = cvr,
+            Number_Pattern_c = pattern,
+            Product_type__c = productType
+        );
+        return series;
+        // Actual insert will be done in test setup if needed for getLocalAssignments,
+        // but primarily for mocking getAllAccountPhoneNumberSeries.
+    }
+
+    // Updated Helper to create Account_Phone_Number_Assignment__c records for testing
+    private static Account_Phone_Number_Assignment__c createTestAssignment(
+        String phoneNumber, String ctnStatus, Id seriesId, Id accountId // Added accountId
+    ) {
+        // Name is an Auto Number field.
         Account_Phone_Number_Assignment__c assignment = new Account_Phone_Number_Assignment__c(
-            Name = phoneNumber, // Assuming Name is the phone number
-            Status__c = status, // Placeholder field
-            Series__c = series   // Placeholder field
-            // Add other necessary fields as per object definition
+            Phone_Number__c = phoneNumber,
+            CTN_Number_Status__c = ctnStatus,
+            Account_Phone_Number_Series__c = seriesId, // Master-Detail
+            Account__c = accountId // Optional Account lookup
+            // Add other necessary fields as per object definition if needed for tests
         );
         return assignment;
     }
 
-    // Helper to create NumberResDAO.NumberData for mock remote responses
+    // Helper to create NumberResDAO.NumberData for mock remote responses (remains mostly the same)
     private static NumberResDAO.NumberData createRemoteData(String phoneNumber, String status, String group) {
         NumberResDAO.NumberData data = new NumberResDAO.NumberData();
         data.phoneNumber = phoneNumber;
-        data.numberStatus = status;
-        data.numberGroup = group;
-        // productType, countryCode, id etc. can be populated if needed for logic
+        data.numberStatus = status; // This maps to CTN_Number_Status__c
+        data.numberGroup = group;   // This is informational, actual series link is via parentSeriesId
         return data;
+    }
+
+    // Helper to create mock OpenPhoneNumberSeries__mdt records for testing.
+    // This is for providing to the mock service, not for DML.
+    private static OpenPhoneNumberSeries__mdt createMockOpenSeriesMetadata(String numberGroup, String numberLocation) {
+        OpenPhoneNumberSeries__mdt seriesMeta = new OpenPhoneNumberSeries__mdt(
+            // Assuming API names on CMD are NumberGroup__c and NumberLocation__c
+            NumberGroup__c = numberGroup,
+            NumberLocation__c = numberLocation
+        );
+        return seriesMeta;
     }
 
     @TestVisible
     private class MockPhoneNumberSyncService extends PhoneNumberSyncService {
         private Map<String, List<NumberResDAO.NumberData>> mockRemoteDataBySeriesAndStatus;
-        public List<String> calledParamsKeys = new List<String>(); // To track calls
+        public List<String> calledParamsKeys = new List<String>();
 
-        MockPhoneNumberSyncService(Map<String, List<NumberResDAO.NumberData>> mockData) {
+        // Data for mocking the new virtual methods
+        private List<Account_Phone_Number_Series__c> mockSeriesRecords;
+        private List<OpenPhoneNumberSeries__mdt> mockOpenSeriesMetadata;
+
+        MockPhoneNumberSyncService(
+            Map<String, List<NumberResDAO.NumberData>> mockRemoteData,
+            List<Account_Phone_Number_Series__c> seriesRecords,
+            List<OpenPhoneNumberSeries__mdt> openSeriesMeta
+        ) {
             super();
-            this.mockRemoteDataBySeriesAndStatus = mockData;
+            this.mockRemoteDataBySeriesAndStatus = mockRemoteData;
+            this.mockSeriesRecords = seriesRecords;
+            this.mockOpenSeriesMetadata = openSeriesMeta;
         }
 
         @Override
         protected NumberResDAO.NumberDetails callGetNumberDetails(NumberService.GetNumbersParameterbuilder params) {
             NumberResDAO.NumberDetails details = new NumberResDAO.NumberDetails();
             details.data = new List<NumberResDAO.NumberData>();
-
-            String key = params.numberGroup + '_' + params.numberStatus;
-            calledParamsKeys.add(key); // Record the call parameters key
+            // Key for mockRemoteDataBySeriesAndStatus might need to consider location if group alone is not unique
+            String key = params.numberGroup + '_' + params.numberLocation + '_' + params.numberStatus;
+            calledParamsKeys.add(key);
 
             if (mockRemoteDataBySeriesAndStatus != null && mockRemoteDataBySeriesAndStatus.containsKey(key)) {
                  details.data.addAll(mockRemoteDataBySeriesAndStatus.get(key));
             }
             return details;
         }
+
+        @Override
+        protected List<Account_Phone_Number_Series__c> getAllAccountPhoneNumberSeries() {
+            return this.mockSeriesRecords != null ? this.mockSeriesRecords : super.getAllAccountPhoneNumberSeries();
+        }
+
+        @Override
+        protected List<OpenPhoneNumberSeries__mdt> getOpenPhoneNumberSeriesMetadata() {
+            return this.mockOpenSeriesMetadata != null ? this.mockOpenSeriesMetadata : super.getOpenPhoneNumberSeriesMetadata();
+        }
     }
 
-    // ... (testCreateNewAssignments, testUpdateExistingAssignments, testDeleteObsoleteAssignments remain the same) ...
+    // ... (Keep all helper methods: createTestSeries, createTestAssignment, createRemoteData, createMockOpenSeriesMetadata) ...
+    // ... (Keep MockPhoneNumberSyncService inner class as defined in the previous step) ...
+
     @isTest
     static void testCreateNewAssignments() {
+        // 1. Setup Mock Series Data
+        List<Account_Phone_Number_Series__c> testSeriesList = new List<Account_Phone_Number_Series__c>{
+            createTestSeries('GRP1', 'LOCA', 'cvr1', 'pattern1', 'GSM')
+        };
+        // Insert the series to get an Id, needed if we were creating local assignments
+        // For this test (create), local assignments are empty, so series Id is mainly for remote mapping.
+        // However, the service fetches series from DB via getAllAccountPhoneNumberSeries,
+        // so our mock must provide it. If not inserting, ensure mockSeriesRecords has Ids if logic depends on it.
+        // For simplicity, we'll assume mockSeriesRecords can contain records with null Ids if the SUT handles it,
+        // or we ensure they have Ids if parentSeriesId in RemoteAssignmentWrapper *must* be a real Id.
+        // The current SUT's getRemoteAssignments passes seriesRecord.Id, so it should be a valid Id.
+        insert testSeriesList; // So testSeriesList[0].Id is populated for parentSeriesId
+
+        // 2. Setup Mock Open Series CMD (empty for this test, assuming GRP1_LOCA is not open)
+        List<OpenPhoneNumberSeries__mdt> testOpenSeriesList = new List<OpenPhoneNumberSeries__mdt>();
+
+        // 3. No Local Assignments for this test
+
+        // 4. Setup Mock Remote Payload (keyed by Group_Location_Status)
         Map<String, List<NumberResDAO.NumberData>> mockRemotePayload =
             new Map<String, List<NumberResDAO.NumberData>>{
-                'Series1_AA' => new List<NumberResDAO.NumberData>{
-                    createRemoteData('1112223333', 'AA', 'Series1'),
-                    createRemoteData('4445556666', 'AA', 'Series1')
+                'GRP1_LOCA_AA' => new List<NumberResDAO.NumberData>{
+                    createRemoteData('PHONE001', 'AA', 'GRP1'), // numberGroup in remoteData is informational
+                    createRemoteData('PHONE002', 'AA', 'GRP1')
                 }
-                // Add other series from `allSeries` to prevent unexpected deletions if they are queried
-                // For 'Series2' and 'OpenSeries1' (if it's not the one being tested as open here)
-                // Ensure they return empty lists if no data is expected for them in this specific test.
-                ,'Series2_AA' => new List<NumberResDAO.NumberData>(), 'Series2_AR' => new List<NumberResDAO.NumberData>(),
-                'Series2_AI' => new List<NumberResDAO.NumberData>(), 'Series2_AS' => new List<NumberResDAO.NumberData>(),
-                'OpenSeries1_AR' => new List<NumberResDAO.NumberData>() // Assuming OpenSeries1 is handled elsewhere or empty
+                // Ensure other statuses for GRP1_LOCA return empty if queried
+                ,'GRP1_LOCA_AR' => new List<NumberResDAO.NumberData>()
+                ,'GRP1_LOCA_AI' => new List<NumberResDAO.NumberData>()
+                ,'GRP1_LOCA_AS' => new List<NumberResDAO.NumberData>()
             };
 
         Test.startTest();
-        // Note: The PhoneNumberSyncService uses a hardcoded `allSeries` list:
-        // List<String> allSeries = new List<String>{'Series1', 'Series2', 'OpenSeries1'};
-        // And queries OpenPhoneNumberSeries__mdt. If 'OpenSeries1' is not in CMD for this test, it's treated as regular.
-        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(mockRemotePayload);
+        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(
+            mockRemotePayload, testSeriesList, testOpenSeriesList
+        );
         service.synchronizeAssignments();
         Test.stopTest();
 
         List<Account_Phone_Number_Assignment__c> created = [
-            SELECT Name, Status__c, Series__c FROM Account_Phone_Number_Assignment__c
+            SELECT Phone_Number__c, CTN_Number_Status__c, Account_Phone_Number_Series__c
+            FROM Account_Phone_Number_Assignment__c
         ];
-        System.assertEquals(2, created.size(), 'Should create 2 new assignments from Series1_AA.');
-        Set<String> createdNumbers = new Set<String>();
+        System.assertEquals(2, created.size(), 'Should create 2 new assignments.');
+        Set<String> createdPhones = new Set<String>();
         for(Account_Phone_Number_Assignment__c asn : created) {
-            createdNumbers.add(asn.Name);
-            if(asn.Name == '1112223333' || asn.Name == '4445556666') {
-                System.assertEquals('AA', asn.Status__c);
-                System.assertEquals('Series1', asn.Series__c);
-            }
+            createdPhones.add(asn.Phone_Number__c);
+            System.assertEquals(testSeriesList[0].Id, asn.Account_Phone_Number_Series__c, 'Series should match.');
+            System.assertEquals('AA', asn.CTN_Number_Status__c, 'Status should be AA.');
         }
-        System.assert(createdNumbers.contains('1112223333'));
-        System.assert(createdNumbers.contains('4445556666'));
+        System.assert(createdPhones.contains('PHONE001'), 'PHONE001 should be created.');
+        System.assert(createdPhones.contains('PHONE002'), 'PHONE002 should be created.');
     }
 
     @isTest
     static void testUpdateExistingAssignments() {
+        // 1. Setup Series (insert to get Id)
+        List<Account_Phone_Number_Series__c> testSeriesList = new List<Account_Phone_Number_Series__c>{
+            createTestSeries('GRP1', 'LOCA', 'cvr1', 'pattern1', 'GSM')
+        };
+        insert testSeriesList;
+        Id series1Id = testSeriesList[0].Id;
+
+        // 2. Setup Open Series CMD (empty for this test)
+        List<OpenPhoneNumberSeries__mdt> testOpenSeriesList = new List<OpenPhoneNumberSeries__mdt>();
+
+        // 3. Setup Local Assignments
         List<Account_Phone_Number_Assignment__c> localAssignments = new List<Account_Phone_Number_Assignment__c>{
-            createLocalAssignment('1234567890', 'AA', 'Series1')
+            createTestAssignment('PHONE001', 'AA', series1Id, null)
         };
         insert localAssignments;
 
+        // 4. Setup Mock Remote Payload - PHONE001 status changes from AA to AR
         Map<String, List<NumberResDAO.NumberData>> mockRemotePayload =
             new Map<String, List<NumberResDAO.NumberData>>{
-                'Series1_AA' => new List<NumberResDAO.NumberData>{
-                    createRemoteData('1234567890', 'AR', 'Series1')
+                'GRP1_LOCA_AA' => new List<NumberResDAO.NumberData>{ // Remote data might still come with original status
+                    createRemoteData('PHONE001', 'AR', 'GRP1')
                 },
-                // Add other series from `allSeries` to prevent unexpected deletions
-                'Series1_AR' => new List<NumberResDAO.NumberData>(),
-                'Series1_AI' => new List<NumberResDAO.NumberData>(),
-                'Series1_AS' => new List<NumberResDAO.NumberData>(),
-                'Series2_AA' => new List<NumberResDAO.NumberData>(), 'Series2_AR' => new List<NumberResDAO.NumberData>(),
-                'Series2_AI' => new List<NumberResDAO.NumberData>(), 'Series2_AS' => new List<NumberResDAO.NumberData>(),
-                'OpenSeries1_AR' => new List<NumberResDAO.NumberData>()
+                'GRP1_LOCA_AR' => new List<NumberResDAO.NumberData>(), // Ensure empty for other statuses
+                'GRP1_LOCA_AI' => new List<NumberResDAO.NumberData>(),
+                'GRP1_LOCA_AS' => new List<NumberResDAO.NumberData>()
             };
+        // It's also possible the remote system now reports PHONE001 under AR status directly.
+        // Let's assume the service queries all statuses for non-open series.
+        // If PHONE001 is now 'AR', it might be returned when 'AR' status is queried.
+        // For simplicity, let's assume it's found when GRP1_LOCA_AA is queried, but data says AR.
+        // The SUT's `compareAndPrepareDML` uses `remoteData.numberStatus` for comparison.
 
         Test.startTest();
-        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(mockRemotePayload);
+        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(
+            mockRemotePayload, testSeriesList, testOpenSeriesList
+        );
         service.synchronizeAssignments();
         Test.stopTest();
 
-        List<Account_Phone_Number_Assignment__c> updated = [
-            SELECT Name, Status__c, Series__c FROM Account_Phone_Number_Assignment__c WHERE Name = '1234567890'
+        List<Account_Phone_Number_Assignment__c> updatedList = [
+            SELECT Phone_Number__c, CTN_Number_Status__c FROM Account_Phone_Number_Assignment__c
+            WHERE Phone_Number__c = 'PHONE001'
         ];
-        System.assertEquals(1, updated.size());
-        System.assertEquals('AR', updated[0].Status__c);
-        System.assertEquals('Series1', updated[0].Series__c);
+        System.assertEquals(1, updatedList.size(), 'Should be 1 assignment for PHONE001.');
+        System.assertEquals('AR', updatedList[0].CTN_Number_Status__c, 'Status should be updated to AR.');
     }
 
     @isTest
     static void testDeleteObsoleteAssignments() {
+        // 1. Setup Series
+        List<Account_Phone_Number_Series__c> testSeriesList = new List<Account_Phone_Number_Series__c>{
+            createTestSeries('GRP1', 'LOCA', 'cvr1', 'pattern1', 'GSM'), // Series for deletion
+            createTestSeries('GRP2', 'LOCB', 'cvr2', 'pattern2', 'GSM')  // Series to keep an assignment
+        };
+        insert testSeriesList;
+        Id series1Id = testSeriesList[0].Id;
+        Id series2Id = testSeriesList[1].Id;
+
+        // 2. Setup Open Series CMD (empty)
+        List<OpenPhoneNumberSeries__mdt> testOpenSeriesList = new List<OpenPhoneNumberSeries__mdt>();
+
+        // 3. Setup Local Assignments
         List<Account_Phone_Number_Assignment__c> localAssignments = new List<Account_Phone_Number_Assignment__c>{
-            createLocalAssignment('0987654321', 'AA', 'Series1'),
-            createLocalAssignment('1111111111', 'AA', 'Series2') // Added one in Series2
+            createTestAssignment('PHONE_TO_DELETE', 'AA', series1Id, null),
+            createTestAssignment('PHONE_TO_KEEP', 'AA', series2Id, null)
         };
         insert localAssignments;
 
-        // Remote data for Series1 is empty, implying 0987654321 is obsolete.
-        // Remote data for Series2_AA has one record, so 1111111111 should NOT be deleted.
+        // 4. Setup Mock Remote Payload
+        // GRP1_LOCA returns no numbers (so PHONE_TO_DELETE is obsolete)
+        // GRP2_LOCB returns PHONE_TO_KEEP
         Map<String, List<NumberResDAO.NumberData>> mockRemotePayload =
             new Map<String, List<NumberResDAO.NumberData>>{
-                'Series1_AA' => new List<NumberResDAO.NumberData>(), 'Series1_AR' => new List<NumberResDAO.NumberData>(),
-                'Series1_AI' => new List<NumberResDAO.NumberData>(), 'Series1_AS' => new List<NumberResDAO.NumberData>(),
-                'Series2_AA' => new List<NumberResDAO.NumberData>{ createRemoteData('1111111111', 'AA', 'Series2') }, // Keep this one
-                'Series2_AR' => new List<NumberResDAO.NumberData>(),
-                'Series2_AI' => new List<NumberResDAO.NumberData>(), 'Series2_AS' => new List<NumberResDAO.NumberData>(),
-                'OpenSeries1_AR' => new List<NumberResDAO.NumberData>()
+                'GRP1_LOCA_AA' => new List<NumberResDAO.NumberData>(),
+                'GRP1_LOCA_AR' => new List<NumberResDAO.NumberData>(),
+                'GRP1_LOCA_AI' => new List<NumberResDAO.NumberData>(),
+                'GRP1_LOCA_AS' => new List<NumberResDAO.NumberData>(),
+                'GRP2_LOCB_AA' => new List<NumberResDAO.NumberData>{
+                    createRemoteData('PHONE_TO_KEEP', 'AA', 'GRP2')
+                },
+                'GRP2_LOCB_AR' => new List<NumberResDAO.NumberData>(),
+                'GRP2_LOCB_AI' => new List<NumberResDAO.NumberData>(),
+                'GRP2_LOCB_AS' => new List<NumberResDAO.NumberData>()
             };
 
         Test.startTest();
-        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(mockRemotePayload);
+        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(
+            mockRemotePayload, testSeriesList, testOpenSeriesList
+        );
         service.synchronizeAssignments();
         Test.stopTest();
 
-        List<Account_Phone_Number_Assignment__c> remaining = [
-            SELECT Name FROM Account_Phone_Number_Assignment__c
+        List<Account_Phone_Number_Assignment__c> remainingAssignments = [
+            SELECT Phone_Number__c FROM Account_Phone_Number_Assignment__c
         ];
-        System.assertEquals(1, remaining.size(), 'Only one assignment should remain.');
-        System.assertEquals('1111111111', remaining[0].Name, 'Assignment 1111111111 from Series2 should remain.');
+        System.assertEquals(1, remainingAssignments.size(), 'Only one assignment should remain.');
+        System.assertEquals('PHONE_TO_KEEP', remainingAssignments[0].Phone_Number__c, 'PHONE_TO_KEEP should remain.');
     }
 
     @isTest
     static void testOpenPhoneNumberSeriesHandling() {
-        // 1. Setup Custom Metadata for 'OpenSeries1'
-        // Note: Custom metadata DML is not directly supported.
-        // We rely on the metadata being deployed or use Test.loadData if it were a custom object.
-        // For tests, we assume OpenPhoneNumberSeries__mdt with DeveloperName 'OpenSeries1' exists,
-        // or we adjust PhoneNumberSyncService to query a mockable source for open series names in tests.
-        // For this iteration, we assume the CMD query works IF the metadata for 'OpenSeries1' is present.
-        // If not, this test might not correctly test the "open series" path.
-        // Let's proceed assuming 'OpenSeries1' is correctly identified as open by the main code.
+        // 1. Setup Series: One regular, one matching the open series CMD criteria
+        List<Account_Phone_Number_Series__c> testSeriesList = new List<Account_Phone_Number_Series__c>{
+            createTestSeries('STD', 'LOC_STD', 'cvr_std', 'p_std', 'GSM'), // Standard series
+            createTestSeries('P', 'EKC', 'cvr_open', 'p_open', 'GSM')     // This matches open series criteria
+        };
+        insert testSeriesList; // For Ids
 
-        // 2. Setup mock remote payload
+        // 2. Setup Mock Open Series CMD (as per user spec: P, EKC is open)
+        List<OpenPhoneNumberSeries__mdt> testOpenSeriesList = new List<OpenPhoneNumberSeries__mdt>{
+            createMockOpenSeriesMetadata('P', 'EKC')
+        };
+
+        // 3. No Local Assignments for this test (focus on creation & call behavior)
+
+        // 4. Setup Mock Remote Payload
         Map<String, List<NumberResDAO.NumberData>> mockRemotePayload =
             new Map<String, List<NumberResDAO.NumberData>>{
-                // Data for a regular series (Series1) - expecting calls for AA, AR, AI, AS
-                'Series1_AA' => new List<NumberResDAO.NumberData>{ createRemoteData('REG001', 'AA', 'Series1') },
-                'Series1_AR' => new List<NumberResDAO.NumberData>(),
-                'Series1_AI' => new List<NumberResDAO.NumberData>(),
-                'Series1_AS' => new List<NumberResDAO.NumberData>(),
-                // Data for an open series (OpenSeries1) - expecting call only for AR
-                'OpenSeries1_AR' => new List<NumberResDAO.NumberData>{ createRemoteData('OPEN001', 'AR', 'OpenSeries1') },
-                // Data for another regular series (Series2) - expecting calls for AA, AR, AI, AS
-                'Series2_AA' => new List<NumberResDAO.NumberData>(), 'Series2_AR' => new List<NumberResDAO.NumberData>(),
-                'Series2_AI' => new List<NumberResDAO.NumberData>(), 'Series2_AS' => new List<NumberResDAO.NumberData>()
+                // Standard Series STD_LOC_STD: Expect calls for AA, AR, AI, AS. Provide data for AA.
+                'STD_LOC_STD_AA' => new List<NumberResDAO.NumberData>{ createRemoteData('STD_PHONE1', 'AA', 'STD') },
+                'STD_LOC_STD_AR' => new List<NumberResDAO.NumberData>(),
+                'STD_LOC_STD_AI' => new List<NumberResDAO.NumberData>(),
+                'STD_LOC_STD_AS' => new List<NumberResDAO.NumberData>(),
+                // Open Series P_EKC: Expect call only for AR. Provide data for AR.
+                'P_EKC_AR' => new List<NumberResDAO.NumberData>{ createRemoteData('OPEN_PHONE1', 'AR', 'P') }
+                // No data for P_EKC_AA, P_EKC_AI, P_EKC_AS as they shouldn't be called.
             };
 
-        // No local assignments for simplicity in this test, focusing on call behavior and creation.
-
         Test.startTest();
-        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(mockRemotePayload);
-        // To properly test OpenPhoneNumberSeries__mdt, we need to ensure it's populated for the test run.
-        // If not deploying, this test relies on the hardcoded `allSeries` and the default behavior if CMD is empty.
-        // Let's assume 'OpenSeries1' is one of the `allSeries` and is correctly identified as open.
-        // The `PhoneNumberSyncService` has `List<String> allSeries = new List<String>{'Series1', 'Series2', 'OpenSeries1'};`
-        // And `getRemoteAssignments` queries `OpenPhoneNumberSeries__mdt`. If 'OpenSeries1' is in this CMD, it's "open".
-
-        // To ensure 'OpenSeries1' is treated as open, we would typically insert OpenPhoneNumberSeries__mdt.
-        // However, direct DML on CMD is not allowed. Tests run with access to existing metadata.
-        // So, this test assumes 'OpenSeries1' (DeveloperName) exists as an OpenPhoneNumberSeries__mdt record.
-        // If it does not, 'OpenSeries1' will be treated as a *regular* series by the production code.
-
+        MockPhoneNumberSyncService service = new MockPhoneNumberSyncService(
+            mockRemotePayload, testSeriesList, testOpenSeriesList
+        );
         service.synchronizeAssignments();
         Test.stopTest();
 
-        // 3. Assert DML outcomes
+        // Assert DML outcomes
         List<Account_Phone_Number_Assignment__c> created = [
-            SELECT Name, Status__c, Series__c FROM Account_Phone_Number_Assignment__c
+            SELECT Phone_Number__c, CTN_Number_Status__c, Account_Phone_Number_Series__r.Number_Group__c
+            FROM Account_Phone_Number_Assignment__c
+            ORDER BY Phone_Number__c
         ];
-        System.assertEquals(2, created.size(), 'Should create one regular and one open series assignment.');
+        System.assertEquals(2, created.size(), 'Should create one std and one open series assignment.');
+        System.assertEquals('OPEN_PHONE1', created[0].Phone_Number__c);
+        System.assertEquals('AR', created[0].CTN_Number_Status__c);
+        System.assertEquals('P', created[0].Account_Phone_Number_Series__r.Number_Group__c);
 
-        Set<String> createdPhoneNumbers = new Set<String>();
-        for(Account_Phone_Number_Assignment__c asn : created) {
-            createdPhoneNumbers.add(asn.Name);
-        }
-        System.assert(createdPhoneNumbers.contains('REG001'), 'Regular assignment REG001 should be created.');
-        System.assert(createdPhoneNumbers.contains('OPEN001'), 'Open series assignment OPEN001 should be created.');
+        System.assertEquals('STD_PHONE1', created[1].Phone_Number__c);
+        System.assertEquals('AA', created[1].CTN_Number_Status__c);
+        System.assertEquals('STD', created[1].Account_Phone_Number_Series__r.Number_Group__c);
 
-        // 4. Assert that callGetNumberDetails was called with expected parameters
+        // Assert call behavior
         Set<String> expectedCallKeys = new Set<String>{
-            'Series1_AA', 'Series1_AR', 'Series1_AI', 'Series1_AS', // Regular series
-            'OpenSeries1_AR',                                      // Open series (only AR)
-            'Series2_AA', 'Series2_AR', 'Series2_AI', 'Series2_AS'  // Another regular series
+            'STD_LOC_STD_AA', 'STD_LOC_STD_AR', 'STD_LOC_STD_AI', 'STD_LOC_STD_AS', // Standard series
+            'P_EKC_AR'                                                          // Open series (only AR)
         };
 
         System.assertEquals(expectedCallKeys.size(), service.calledParamsKeys.size(),
-            'Mock service should be called for specific series/status combinations. Called: ' + service.calledParamsKeys);
-
+            'Called keys count mismatch. Called: ' + service.calledParamsKeys);
         for(String key : expectedCallKeys) {
-            System.assert(service.calledParamsKeys.contains(key),
-                'Expected callGetNumberDetails with key: ' + key + '. Actual calls: ' + service.calledParamsKeys);
+            System.assert(service.calledParamsKeys.contains(key), 'Expected call key: ' + key + '. Actual calls: ' + service.calledParamsKeys);
         }
-        // Verify OpenSeries1 was NOT called with AA, AI, AS
-        System.assert(!service.calledParamsKeys.contains('OpenSeries1_AA'), 'OpenSeries1 should not be called with AA.');
-        System.assert(!service.calledParamsKeys.contains('OpenSeries1_AI'), 'OpenSeries1 should not be called with AI.');
-        System.assert(!service.calledParamsKeys.contains('OpenSeries1_AS'), 'OpenSeries1 should not be called with AS.');
+        System.assert(!service.calledParamsKeys.contains('P_EKC_AA'), 'P_EKC_AA should not have been called.');
+        System.assert(!service.calledParamsKeys.contains('P_EKC_AI'), 'P_EKC_AI should not have been called.');
+        System.assert(!service.calledParamsKeys.contains('P_EKC_AS'), 'P_EKC_AS should not have been called.');
     }
 }


### PR DESCRIPTION
I refactored PhoneNumberSyncService and its tests to use your newly defined custom objects: Account_Phone_Number_Series__c and Account_Phone_Number_Assignment__c, and the OpenPhoneNumberSeries__mdt custom metadata type.

Key changes:
- PhoneNumberSyncService:
  - I updated getLocalAssignments to query Account_Phone_Number_Assignment__c using its new fields (e.g., Phone_Number__c, CTN_Number_Status__c) and keying by Phone_Number__c.
  - I updated getRemoteAssignments to:
    - Query Account_Phone_Number_Series__c to dynamically fetch all series data (number group, location, CVR, pattern) instead of using a hardcoded list.
    - Query OpenPhoneNumberSeries__mdt (using NumberGroup__c, NumberLocation__c fields) to identify open series.
    - Pass series-specific parameters to NumberService.getNumberDetails.
    - Return a wrapper object containing remote number data and the parent Account_Phone_Number_Series__c Id.
  - I updated compareAndPrepareDML to:
    - Use the new fields from Account_Phone_Number_Assignment__c.
    - Correctly populate the Account_Phone_Number_Series__c master-detail lookup when creating new assignments.

- PhoneNumberSyncServiceTests:
  - I updated test data helper methods to create instances of the new custom objects.
  - I enhanced MockPhoneNumberSyncService to allow injection of mock Account_Phone_Number_Series__c and OpenPhoneNumberSeries__mdt data.
  - I refactored all test methods to use the new helpers and mock capabilities.
  - Assertions now verify logic against the new object structures, field names, and relationships, including specific call patterns for open series.

This refactoring aligns the synchronization logic with your specified Salesforce data model.